### PR TITLE
chore: :wrench: add scopes for cc vscode extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "conventionalCommits.scopes": [
+    "server",
+    "client"
+  ]
+}


### PR DESCRIPTION
Nur zwei scopes (client; server) zur Conventional Commits Extension in VSCode hinzugefügt